### PR TITLE
Moved to the new package restore mecanism

### DIFF
--- a/ReplaceEmbeddedAssemblyResource.sln
+++ b/ReplaceEmbeddedAssemblyResource.sln
@@ -1,13 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReplaceEmbeddedAssemblyResource", "ReplaceEmbeddedAssemblyResource\ReplaceEmbeddedAssemblyResource.csproj", "{72BE1037-D596-4360-9463-4FB1FFE8648B}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{6ED735B0-B0EC-4A60-9970-778058E2BC9E}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.Config = .nuget\NuGet.Config
 		.nuget\NuGet.exe = .nuget\NuGet.exe
-		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
 Global

--- a/ReplaceEmbeddedAssemblyResource/ReplaceEmbeddedAssemblyResource.csproj
+++ b/ReplaceEmbeddedAssemblyResource/ReplaceEmbeddedAssemblyResource.csproj
@@ -64,7 +64,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
The .targets file is not present in the repository and it prevents the projet from opening. (RE: Issue #1 )
On top of that, the .targets file is not the preferred way of using package restore since NuGet 2.7. All of that had been automatized by IDE integration.

I don't know if this holds true for Xamarin Studio, which you (@qerub) mentioned you were using...
