### PR TITLE
Update Mono.Cecil and use FileStream to replace EmbeddedResource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ obj/
 [Rr]elease*/
 _ReSharper*/
 [Tt]est[Rr]esult*
+/.vs

--- a/ReplaceEmbeddedAssemblyResource.sln
+++ b/ReplaceEmbeddedAssemblyResource.sln
@@ -1,15 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2041
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReplaceEmbeddedAssemblyResource", "ReplaceEmbeddedAssemblyResource\ReplaceEmbeddedAssemblyResource.csproj", "{72BE1037-D596-4360-9463-4FB1FFE8648B}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{6ED735B0-B0EC-4A60-9970-778058E2BC9E}"
-	ProjectSection(SolutionItems) = preProject
-		.nuget\NuGet.Config = .nuget\NuGet.Config
-		.nuget\NuGet.exe = .nuget\NuGet.exe
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,5 +18,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C6582B76-7D06-4211-BB3C-85069D8BD18F}
 	EndGlobalSection
 EndGlobal

--- a/ReplaceEmbeddedAssemblyResource/Program.cs
+++ b/ReplaceEmbeddedAssemblyResource/Program.cs
@@ -41,15 +41,21 @@ namespace ReplaceEmbeddedAssemblyResource
 
             if (selectedResource != null)
             {
-                var newResource = new EmbeddedResource(resourceName, selectedResource.Attributes, File.ReadAllBytes(resourcePath));
-                resources.Remove(selectedResource);
-                resources.Add(newResource);
-                if (snkPath == null)
-                    assemblyDef.Write(newAssemblyPath);
-                else
+                using (var filestream = File.OpenRead(resourcePath))
                 {
-                    Console.WriteLine("Using strong name key file " + snkPath);
-                    assemblyDef.Write(newAssemblyPath, new WriterParameters() { StrongNameKeyPair = new StrongNameKeyPair(File.ReadAllBytes(snkPath)) });
+                    var newResource = new EmbeddedResource(resourceName, selectedResource.Attributes, filestream);
+                    resources.Remove(selectedResource);
+                    resources.Add(newResource);
+
+                    if (snkPath == null)
+                    {
+                        assemblyDef.Write(newAssemblyPath);
+                    }
+                    else
+                    {
+                        Console.WriteLine("Using strong name key file " + snkPath);
+                        assemblyDef.Write(newAssemblyPath, new WriterParameters() { StrongNameKeyPair = new StrongNameKeyPair(File.ReadAllBytes(snkPath)) });
+                    }
                 }
 
                 Console.WriteLine("Replaced embedded resource " + resourceName + " successfully!");

--- a/ReplaceEmbeddedAssemblyResource/ReplaceEmbeddedAssemblyResource.csproj
+++ b/ReplaceEmbeddedAssemblyResource/ReplaceEmbeddedAssemblyResource.csproj
@@ -35,17 +35,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.dll</HintPath>
+    <Reference Include="Mono.Cecil, Version=0.10.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.1\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.10.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.1\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.10.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.1\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.10.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.1\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/ReplaceEmbeddedAssemblyResource/packages.config
+++ b/ReplaceEmbeddedAssemblyResource/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Mono.Cecil" version="0.9.5.4" targetFramework="net45" />
+  <package id="Mono.Cecil" version="0.10.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Hi,
I have updated Mono.Cecil to the latest version and used the EmbeddedResource with a filestream. We replace a lot of bigger embedded resources on an ARM system with not much memory available, so this prevents to load the complete file into the memory before starting to replace the embedded resource.