### PR TITLE
Use FileStream to replace embedded resources to prevent huge memory use

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -41,15 +41,21 @@ namespace ReplaceEmbeddedAssemblyResource
 
             if (selectedResource != null)
             {
-                var newResource = new EmbeddedResource(resourceName, selectedResource.Attributes, File.ReadAllBytes(resourcePath));
-                resources.Remove(selectedResource);
-                resources.Add(newResource);
-                if (snkPath == null)
-                    assemblyDef.Write(newAssemblyPath);
-                else
+                using (var filestream = File.OpenRead(resourcePath))
                 {
-                    Console.WriteLine("Using strong name key file " + snkPath);
-                    assemblyDef.Write(newAssemblyPath, new WriterParameters() { StrongNameKeyPair = new StrongNameKeyPair(File.ReadAllBytes(snkPath)) });
+                    var newResource = new EmbeddedResource(resourceName, selectedResource.Attributes, filestream);
+                    resources.Remove(selectedResource);
+                    resources.Add(newResource);
+
+                    if (snkPath == null)
+                    {
+                        assemblyDef.Write(newAssemblyPath);
+                    }
+                    else
+                    {
+                        Console.WriteLine("Using strong name key file " + snkPath);
+                        assemblyDef.Write(newAssemblyPath, new WriterParameters() { StrongNameKeyPair = new StrongNameKeyPair(File.ReadAllBytes(snkPath)) });
+                    }
                 }
 
                 Console.WriteLine("Replaced embedded resource " + resourceName + " successfully!");


### PR DESCRIPTION
This PR is the basically the same as #5 but has adjustments for current `master` (that now uses .NET Core). Description from original PR: "We replace a lot of bigger embedded resources on an ARM system with not much memory available, so this prevents to load the complete file into the memory before starting to replace the embedded resource."